### PR TITLE
Check available reserves

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build         	:; forge build
 xclean        	:; forge clean
 deploy        	:; ./scripts/deploy.sh
 lint          	:; yarn run lint
-test            :; forge test --fork-url ${ETH_RPC_URL}
+test            :; forge test --fork-url ${ETH_RPC_URL} -vv
 test-gasreport 	:; forge test --gas-report --fork-url ${ETH_RPC_URL}
 test-fork       :; forge test --gas-report --fork-url ${ETH_RPC_URL}
 watch		  	:; forge test --watch src/ --fork-url ${ETH_RPC_URL}


### PR DESCRIPTION
Revert conversion if BOND reserves are insufficient

Reason: 
- otherwise, users may burn their FDT without being able to claim BOND
- also, this effectively allows an emergency halt of the conversion program by withdrawing BOND reserves

Side-effects:
- increases gas cost for converts and claims slightly